### PR TITLE
GB-3 - Add Jumbotron Header

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,15 @@ We can create a navbar in dark theme potentially (dealer's choice) from the reac
 - The `<Navigation />` should be abstracted into it's own component, just like the `<Router />`
 - Remove React-Bootstrap in favour of the standard Bootstrap package.
 - Create dummy screens for both `<Search />` and `<Saved />`
+
+### GB-3 - Add Jumbotron Header
+
+#### Description
+
+As a user, when I land on the /search (homepage) then I should be able to see a header component that looks like the Bootstrap jumbotron
+
+#### ACs
+
+- There should be a `<Header />` component that has 2 props, the `title` and the `subtitle`
+- The title and subtitle should be aligned to the top of the jumbotron
+- The header should have sufficient margin underneath it for the search bar that is to come.

--- a/src/App.js
+++ b/src/App.js
@@ -3,12 +3,14 @@ import { HashRouter } from "react-router-dom";
 
 import Navigation from "./NavBar";
 import Routes from "./Routes";
+import Header from "./components/Header";
 
 const App = () => {
   return (
     <HashRouter>
       <Navigation />
       <div className="container my-4">
+        <Header />
         <Routes />
       </div>
     </HashRouter>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,0 +1,16 @@
+import React from "react";
+
+const Header = ({
+  title = "Google Books Search",
+  subTitle = "Search for and Save Books of Interest",
+}) => {
+  return (
+    <div class="jumbotron text-center">
+      <h1 class="display-4">{title}</h1>
+      <p class="lead">{subTitle}</p>
+      <hr class="my-4" />
+    </div>
+  );
+};
+
+export default Header;


### PR DESCRIPTION
### GB-3 - Add Jumbotron Header

#### Description
As a user, when I land on the /search (homepage) then I should be able to see a header component that looks like the Bootstrap jumbotron

#### ACs
- There should be a `<Header />` component that has 2 props, the `title` and the `subtitle`
- The title and subtitle should be aligned to the top of the jumbotron
- The header should have sufficient margin underneath it for the search bar that is to come.